### PR TITLE
Add null check for WebPageHelpers.RegexSearch

### DIFF
--- a/UNAProject/tests/UNAProject.FunctionalTests/WebPageHelpers.cs
+++ b/UNAProject/tests/UNAProject.FunctionalTests/WebPageHelpers.cs
@@ -27,7 +27,7 @@ namespace UNAProject.FunctionalTests
         {
             var regex = new Regex(regexpression);
             var match = regex.Match(input);
-            return match.Groups.Values.LastOrDefault().Value;
+            return match.Groups.Values.LastOrDefault()?.Value;
         }
     }
 }


### PR DESCRIPTION
Hi, your project very interesting! But you have little problem:
Method `LastOrDefault` can return null and after this method we use `Value`. This is not good and here can be potential null reference exception. I hope this null check be useful :)